### PR TITLE
Use email for LDAP Search filter instead of eppn

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-VERSION = "0.0.9"
+VERSION = "0.0.11"
 
 with open("README.md", "r") as fh:
     long_description = fh.read()


### PR DESCRIPTION
EPPN LDAP searches fail with new FABRIC-Beta registry.
Use email for LDAP Search filter instead of eppn